### PR TITLE
Added a workaround for SECURITY-170 patch, updated parent pom

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,14 +6,14 @@ All rights reserved.
 Redistribution and use in source and binary forms, with or without modification,
 are permitted provided that the following conditions are met:
 
-    * Redistributions of source code must retain the above copyright notice,
-      this list of conditions and the following disclaimer.
-    * Redistributions in binary form must reproduce the above copyright notice,
-      this list of conditions and the following disclaimer in the documentation
-      and/or other materials provided with the distribution.
-    * Neither the name of the dynaTrace software nor the names of its contributors
-      may be used to endorse or promote products derived from this software without
-      specific prior written permission.
+  * Redistributions of source code must retain the above copyright notice,
+    this list of conditions and the following disclaimer.
+  * Redistributions in binary form must reproduce the above copyright notice,
+    this list of conditions and the following disclaimer in the documentation
+    and/or other materials provided with the distribution.
+  * Neither the name of the dynaTrace software nor the names of its contributors
+    may be used to endorse or promote products derived from this software without
+    specific prior written permission.
 
 THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY
 EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES
@@ -31,7 +31,7 @@ DAMAGE.
   <parent>
     <groupId>org.jenkins-ci.plugins</groupId>
     <artifactId>plugin</artifactId>
-    <version>1.579</version><!-- which version of Jenkins is this plugin built against? -->
+    <version>2.8</version><!-- which version of Jenkins is this plugin built against? -->
   </parent>
 
   <artifactId>dynatrace-dashboard</artifactId>
@@ -62,18 +62,21 @@ DAMAGE.
 
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+    <jenkins.version>1.579</jenkins.version>
+    <findbugs.skip>true</findbugs.skip>
+    <argLine></argLine>
   </properties>
 
   <build>
     <plugins>
       <plugin>
         <artifactId>maven-clean-plugin</artifactId>
-        <version>${maven-clean-plugin.version}</version>
+        <version>3.0.0</version>
       </plugin>
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-compiler-plugin</artifactId>
-        <version>${maven-compiler-plugin.version}</version>
+        <version>3.5.1</version>
         <configuration>
           <source>1.6</source>
           <target>1.6</target>
@@ -99,7 +102,6 @@ DAMAGE.
       <artifactId>test-automation-lib</artifactId>
       <version>6.3</version>
     </dependency>
-
     <dependency>
       <groupId>junit</groupId>
       <artifactId>junit</artifactId>
@@ -129,11 +131,11 @@ DAMAGE.
     <repository>
       <id>local-repo</id>
       <releases>
-          <enabled>true</enabled>
-          <checksumPolicy>ignore</checksumPolicy>
+        <enabled>true</enabled>
+        <checksumPolicy>ignore</checksumPolicy>
       </releases>
       <snapshots>
-          <enabled>false</enabled>
+        <enabled>false</enabled>
       </snapshots>
       <url>file://${project.basedir}/repo</url>
     </repository>

--- a/src/main/java/com/dynatrace/jenkins/dashboard/utils/DynatraceVariablesAction.java
+++ b/src/main/java/com/dynatrace/jenkins/dashboard/utils/DynatraceVariablesAction.java
@@ -1,0 +1,79 @@
+package com.dynatrace.jenkins.dashboard.utils;
+
+import hudson.EnvVars;
+import hudson.Extension;
+import hudson.model.*;
+
+import javax.annotation.Nonnull;
+import java.util.*;
+
+public class DynatraceVariablesAction extends ParametersAction {
+
+	private List<ParameterValue> parameters = new ArrayList<ParameterValue>();
+
+	public DynatraceVariablesAction(Collection<? extends ParameterValue> parameters) {
+		this.parameters.addAll(parameters);
+	}
+
+	@Override
+	public List<ParameterValue> getParameters() {
+		return Collections.unmodifiableList(parameters);
+	}
+
+	@Override
+	public ParameterValue getParameter(String name) {
+		for (ParameterValue p : parameters) {
+			if (p == null) continue;
+			if (p.getName().equals(name))
+				return p;
+		}
+		return null;
+	}
+
+	@Nonnull
+	@Override
+	public DynatraceVariablesAction createUpdated(Collection<? extends ParameterValue> overrides) {
+		List<ParameterValue> newParams = new ArrayList<ParameterValue>(overrides);
+
+		outer:
+		for (ParameterValue value : this.parameters) {
+			for (ParameterValue newParam : newParams) {
+				if (newParam.getName().equals(value.getName())) {
+					continue outer;
+				}
+			}
+			newParams.add(value);
+		}
+
+		return new DynatraceVariablesAction(newParams);
+	}
+
+	@Extension
+	public static final class DynatraceBuildVariablesContributor extends BuildVariableContributor {
+
+		@Override
+		public void buildVariablesFor(AbstractBuild r, Map<String, String> variables) {
+			DynatraceVariablesAction a = r.getAction(DynatraceVariablesAction.class);
+			if (a == null) {
+				return;
+			}
+			for (ParameterValue spv : a.getParameters()) {
+				variables.put(spv.getName(), String.valueOf(spv.getValue()));
+			}
+		}
+	}
+
+	@Extension
+	public static final class DynatraceVariablesEnvironmentContributor extends EnvironmentContributor {
+		@Override
+		public void buildEnvironmentFor(Run r, EnvVars vars, TaskListener listener) {
+			DynatraceVariablesAction a = r.getAction(DynatraceVariablesAction.class);
+			if (a == null) {
+				return;
+			}
+			for (ParameterValue spv : a.getParameters()) {
+				vars.put(spv.getName(), String.valueOf(spv.getValue()));
+			}
+		}
+	}
+}

--- a/src/main/java/com/dynatrace/jenkins/dashboard/utils/Utils.java
+++ b/src/main/java/com/dynatrace/jenkins/dashboard/utils/Utils.java
@@ -33,7 +33,10 @@ import com.dynatrace.jenkins.dashboard.TABuildSetupStatusAction;
 import com.dynatrace.jenkins.dashboard.model_2_0_0.TAReportDetails;
 import com.dynatrace.jenkins.dashboard.model_2_0_0.TestRun;
 import com.dynatrace.jenkins.dashboard.model_2_0_0.TestStatus;
-import hudson.model.*;
+import hudson.model.AbstractBuild;
+import hudson.model.ParameterValue;
+import hudson.model.Result;
+import hudson.model.StringParameterValue;
 import org.w3c.dom.Document;
 import org.xml.sax.InputSource;
 import org.xml.sax.SAXException;
@@ -45,7 +48,10 @@ import java.io.IOException;
 import java.io.PrintStream;
 import java.io.StringReader;
 import java.text.DecimalFormat;
-import java.util.*;
+import java.util.Collections;
+import java.util.EnumMap;
+import java.util.List;
+import java.util.Map;
 
 /**
  * Created by krzysztof.necel on 2016-01-25.
@@ -110,19 +116,16 @@ public final class Utils {
 		return true;
 	}
 
-	public static void updateBuildVariables(AbstractBuild<?,?> build, List<ParameterValue> parameters) {
-		ParametersAction existingAction = build.getAction(ParametersAction.class);
-		final ParametersAction newAction;
+	public static void updateBuildVariables(AbstractBuild<?, ?> build, List<ParameterValue> parameters) {
+		DynatraceVariablesAction existingAction = build.getAction(DynatraceVariablesAction.class);
 		if (existingAction == null) {
-			newAction = new ParametersAction(parameters);
+			build.addAction(new DynatraceVariablesAction(parameters));
 		} else {
-			newAction = existingAction.createUpdated(parameters);
-			build.getActions().remove(existingAction);
+			build.replaceAction(existingAction.createUpdated(parameters));
 		}
-		build.addAction(newAction);
 	}
 
-	public static void updateBuildVariable(AbstractBuild<?,?> build, String key, String value) {
+	public static void updateBuildVariable(AbstractBuild<?, ?> build, String key, String value) {
 		updateBuildVariables(build, Collections.<ParameterValue>singletonList(new StringParameterValue(key, value)));
 	}
 }

--- a/src/main/resources/com/dynatrace/jenkins/dashboard/TABuildWrapper/config.jelly
+++ b/src/main/resources/com/dynatrace/jenkins/dashboard/TABuildWrapper/config.jelly
@@ -1,3 +1,4 @@
+<?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:f="/lib/form">
 
   <f:entry title="${%field.system.profile.title}" description="${%field.system.profile.description}">

--- a/src/main/resources/com/dynatrace/jenkins/dashboard/TAGlobalConfiguration/config.jelly
+++ b/src/main/resources/com/dynatrace/jenkins/dashboard/TAGlobalConfiguration/config.jelly
@@ -1,3 +1,4 @@
+<?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:f="/lib/form">
     <f:section title="${%dynatrace.section.title}" name="dynatrace-test-automation">
 

--- a/src/main/resources/com/dynatrace/jenkins/dashboard/TAReportingBuildAction_2_0_0/index.jelly
+++ b/src/main/resources/com/dynatrace/jenkins/dashboard/TAReportingBuildAction_2_0_0/index.jelly
@@ -1,3 +1,4 @@
+<?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:l="/lib/layout" xmlns:jm="/com/dynatrace/jenkins/dashboard/tags">
 	<j:set var="report" value="${it.currentReport}" />
 	<j:set var="previousReport" value="${it.previousReport}" />

--- a/src/main/resources/com/dynatrace/jenkins/dashboard/TAReportingBuildAction_2_0_0/summary.jelly
+++ b/src/main/resources/com/dynatrace/jenkins/dashboard/TAReportingBuildAction_2_0_0/summary.jelly
@@ -1,3 +1,4 @@
+<?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:t="/lib/hudson" xmlns:jm="/com/dynatrace/jenkins/dashboard/tags">
     <t:summary icon="/plugin/dynatrace-dashboard/images/dynatrace_icon_48x48.png">
         <div>

--- a/src/main/resources/com/dynatrace/jenkins/dashboard/TAReportingProjectAction/floatingBox.jelly
+++ b/src/main/resources/com/dynatrace/jenkins/dashboard/TAReportingProjectAction/floatingBox.jelly
@@ -1,3 +1,4 @@
+<?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core">
     <div style="width:500px; margin: 8px 0px;">
         <div class="test-trend-caption">

--- a/src/main/resources/com/dynatrace/jenkins/dashboard/TAReportingProjectAction/index.jelly
+++ b/src/main/resources/com/dynatrace/jenkins/dashboard/TAReportingProjectAction/index.jelly
@@ -1,3 +1,4 @@
+<?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:l="/lib/layout">
 	<l:layout title="${%project.view.page.title}" css="${JENKINS_CONTEXT_PATH}/plugin/dynatrace-dashboard/css/style.css">
 		<st:include it="${it.project}" page="sidepanel.jelly" />

--- a/src/main/resources/com/dynatrace/jenkins/dashboard/TAReportingProjectAction/jobMain.jelly
+++ b/src/main/resources/com/dynatrace/jenkins/dashboard/TAReportingProjectAction/jobMain.jelly
@@ -1,3 +1,4 @@
+<?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:t="/lib/hudson" xmlns:jm="/com/dynatrace/jenkins/dashboard/tags">
     <table style="margin-top: 1em; margin-left: 1em;">
         <j:set var="buildAction" value="${it.project.lastCompletedBuild.getAction(it.class.classLoader.loadClass('com.dynatrace.jenkins.dashboard.TAReportingBuildAction_2_0_0'))}"/>

--- a/src/main/resources/com/dynatrace/jenkins/dashboard/TAReportingRecorder/config.jelly
+++ b/src/main/resources/com/dynatrace/jenkins/dashboard/TAReportingRecorder/config.jelly
@@ -1,3 +1,4 @@
+<?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:f="/lib/form">
 
   <f:block>

--- a/src/main/resources/com/dynatrace/jenkins/dashboard/TATestRunRegistrationBuildStep/config.jelly
+++ b/src/main/resources/com/dynatrace/jenkins/dashboard/TATestRunRegistrationBuildStep/config.jelly
@@ -1,3 +1,4 @@
+<?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:f="/lib/form">
 
   <f:block>

--- a/src/main/resources/com/dynatrace/jenkins/dashboard/TestAutomationBuildActionResultsDisplay/index.jelly
+++ b/src/main/resources/com/dynatrace/jenkins/dashboard/TestAutomationBuildActionResultsDisplay/index.jelly
@@ -1,3 +1,4 @@
+<?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:l="/lib/layout">
 	<l:layout title="Dynatrace AppMon Test Result" xmlns:jm="/com/dynatrace/jenkins/dashboard/tags"
 		css="${JENKINS_CONTEXT_PATH}/plugin/dynatrace-dashboard/css/style.css">

--- a/src/main/resources/com/dynatrace/jenkins/dashboard/tags/expandableDivHeader.jelly
+++ b/src/main/resources/com/dynatrace/jenkins/dashboard/tags/expandableDivHeader.jelly
@@ -1,3 +1,4 @@
+<?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:d="jelly:define">
 	<j:set var="iconSrc" value="${resURL}/plugin/dynatrace-dashboard/images/${iconName}.png"/>
 	<j:set var="openIconSrc" value="${resURL}/plugin/dynatrace-dashboard/images/${iconName}_open.png"/>

--- a/src/main/resources/com/dynatrace/jenkins/dashboard/tags/oldTestCaseTable.jelly
+++ b/src/main/resources/com/dynatrace/jenkins/dashboard/tags/oldTestCaseTable.jelly
@@ -1,3 +1,4 @@
+<?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:jm="/com/dynatrace/jenkins/dashboard/tags">
 	<h4>${testCase.testCaseName}</h4>
 	<p>

--- a/src/main/resources/com/dynatrace/jenkins/dashboard/tags/oldTestCaseTableRow.jelly
+++ b/src/main/resources/com/dynatrace/jenkins/dashboard/tags/oldTestCaseTableRow.jelly
@@ -1,3 +1,4 @@
+<?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core">
 	<td>${it.getValue()}</td>
 	<td>${it.getHigh()}</td>

--- a/src/main/resources/com/dynatrace/jenkins/dashboard/tags/testResultSummary.jelly
+++ b/src/main/resources/com/dynatrace/jenkins/dashboard/tags/testResultSummary.jelly
@@ -1,3 +1,4 @@
+<?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core">
     (${%test.result.summary.template(report.passedCount, report.improvedCount,
         report.volatileCount, report.degradedCount, report.failedCount)})

--- a/src/main/resources/com/dynatrace/jenkins/dashboard/tags/testResultsDiv.jelly
+++ b/src/main/resources/com/dynatrace/jenkins/dashboard/tags/testResultsDiv.jelly
@@ -1,3 +1,4 @@
+<?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:jm="/com/dynatrace/jenkins/dashboard/tags">
     <j:if test="${testResultsCount > 0}">
         <div>

--- a/src/main/resources/com/dynatrace/jenkins/dashboard/tags/testResultsTable.jelly
+++ b/src/main/resources/com/dynatrace/jenkins/dashboard/tags/testResultsTable.jelly
@@ -1,3 +1,4 @@
+<?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:jm="/com/dynatrace/jenkins/dashboard/tags">
 	<j:set var="previousResult" value="${previousReportDetails.getCorrespondingTestResult(testResult, testCategory)}" />
 

--- a/src/main/resources/com/dynatrace/jenkins/dashboard/tags/testResultsTableRow.jelly
+++ b/src/main/resources/com/dynatrace/jenkins/dashboard/tags/testResultsTableRow.jelly
@@ -1,3 +1,4 @@
+<?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core">
 	<j:choose>
 		<j:when test="${it != null}">

--- a/src/main/resources/com/dynatrace/jenkins/dashboard/tags/testRunDiv.jelly
+++ b/src/main/resources/com/dynatrace/jenkins/dashboard/tags/testRunDiv.jelly
@@ -1,3 +1,4 @@
+<?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:jm="/com/dynatrace/jenkins/dashboard/tags">
     <div>
         <jm:expandableDivHeader headerClass="testRunDivHeader" iconName="arrow_black"

--- a/src/main/resources/index.jelly
+++ b/src/main/resources/index.jelly
@@ -1,3 +1,4 @@
+<?jelly escape-by-default='true'?>
 <!--
   This view is used to render the plugin list page.
 -->

--- a/src/test/java/com/dynatrace/jenkins/dashboard/utils/UtilsTest.java
+++ b/src/test/java/com/dynatrace/jenkins/dashboard/utils/UtilsTest.java
@@ -5,7 +5,6 @@ import com.dynatrace.jenkins.dashboard.model_2_0_0.*;
 import com.google.common.collect.Lists;
 import hudson.model.AbstractBuild;
 import hudson.model.ParameterValue;
-import hudson.model.ParametersAction;
 import hudson.model.StringParameterValue;
 import org.junit.Test;
 import org.mockito.ArgumentCaptor;
@@ -76,7 +75,7 @@ public class UtilsTest {
 	@Test
 	public void updateBuildVariables_NoVariableBefore_Test() {
 		AbstractBuild build = mock(AbstractBuild.class);
-		when(build.getAction(ParametersAction.class)).thenReturn(null);
+		when(build.getAction(DynatraceVariablesAction.class)).thenReturn(null);
 
 		List<ParameterValue> parameters = new ArrayList<ParameterValue>();
 		parameters.add(new StringParameterValue("key1S", "value1"));
@@ -85,9 +84,9 @@ public class UtilsTest {
 
 		Utils.updateBuildVariables(build, parameters);
 
-		ArgumentCaptor<ParametersAction> argumentCaptor = ArgumentCaptor.forClass(ParametersAction.class);
+		ArgumentCaptor<DynatraceVariablesAction> argumentCaptor = ArgumentCaptor.forClass(DynatraceVariablesAction.class);
 		verify(build).addAction(argumentCaptor.capture());
-		ParametersAction updatedAction = argumentCaptor.getValue();
+		DynatraceVariablesAction updatedAction = argumentCaptor.getValue();
 		assertUpdateBuildVariables(updatedAction);
 	}
 
@@ -97,7 +96,7 @@ public class UtilsTest {
 		oldParameters.add(new StringParameterValue("key1S", "value1"));
 
 		AbstractBuild build = mock(AbstractBuild.class);
-		when(build.getAction(ParametersAction.class)).thenReturn(new ParametersAction(oldParameters));
+		when(build.getAction(DynatraceVariablesAction.class)).thenReturn(new DynatraceVariablesAction(oldParameters));
 
 		List<ParameterValue> newParameters = new ArrayList<ParameterValue>();
 		newParameters.add(new StringParameterValue("key2S", "value2"));
@@ -105,9 +104,9 @@ public class UtilsTest {
 
 		Utils.updateBuildVariables(build, newParameters);
 
-		ArgumentCaptor<ParametersAction> argumentCaptor = ArgumentCaptor.forClass(ParametersAction.class);
-		verify(build).addAction(argumentCaptor.capture());
-		ParametersAction updatedAction = argumentCaptor.getValue();
+		ArgumentCaptor<DynatraceVariablesAction> argumentCaptor = ArgumentCaptor.forClass(DynatraceVariablesAction.class);
+		verify(build).replaceAction(argumentCaptor.capture());
+		DynatraceVariablesAction updatedAction = argumentCaptor.getValue();
 		assertUpdateBuildVariables(updatedAction);
 	}
 
@@ -118,16 +117,16 @@ public class UtilsTest {
 		oldParameters.add(new StringParameterValue("key2S", "value2"));
 
 		AbstractBuild build = mock(AbstractBuild.class);
-		when(build.getAction(ParametersAction.class)).thenReturn(new ParametersAction(oldParameters));
+		when(build.getAction(DynatraceVariablesAction.class)).thenReturn(new DynatraceVariablesAction(oldParameters));
 
 		List<ParameterValue> newParameters = new ArrayList<ParameterValue>();
 		newParameters.add(new StringParameterValue("key3S", "value3"));
 
 		Utils.updateBuildVariables(build, newParameters);
 
-		ArgumentCaptor<ParametersAction> argumentCaptor = ArgumentCaptor.forClass(ParametersAction.class);
-		verify(build).addAction(argumentCaptor.capture());
-		ParametersAction updatedAction = argumentCaptor.getValue();
+		ArgumentCaptor<DynatraceVariablesAction> argumentCaptor = ArgumentCaptor.forClass(DynatraceVariablesAction.class);
+		verify(build).replaceAction(argumentCaptor.capture());
+		DynatraceVariablesAction updatedAction = argumentCaptor.getValue();
 		assertUpdateBuildVariables(updatedAction);
 	}
 
@@ -138,17 +137,17 @@ public class UtilsTest {
 		oldParameters.add(new StringParameterValue("key3S", "wrongValue3"));
 
 		AbstractBuild build = mock(AbstractBuild.class);
-		when(build.getAction(ParametersAction.class)).thenReturn(new ParametersAction(oldParameters));
+		when(build.getAction(DynatraceVariablesAction.class)).thenReturn(new DynatraceVariablesAction(oldParameters));
 
 		List<ParameterValue> newParameters = new ArrayList<ParameterValue>();
-		oldParameters.add(new StringParameterValue("key2S", "value2"));
+		newParameters.add(new StringParameterValue("key2S", "value2"));
 		newParameters.add(new StringParameterValue("key3S", "value3"));
 
 		Utils.updateBuildVariables(build, newParameters);
 
-		ArgumentCaptor<ParametersAction> argumentCaptor = ArgumentCaptor.forClass(ParametersAction.class);
-		verify(build).addAction(argumentCaptor.capture());
-		ParametersAction updatedAction = argumentCaptor.getValue();
+		ArgumentCaptor<DynatraceVariablesAction> argumentCaptor = ArgumentCaptor.forClass(DynatraceVariablesAction.class);
+		verify(build).replaceAction(argumentCaptor.capture());
+		DynatraceVariablesAction updatedAction = argumentCaptor.getValue();
 		assertUpdateBuildVariables(updatedAction);
 	}
 
@@ -159,18 +158,18 @@ public class UtilsTest {
 		oldParameters.add(new StringParameterValue("key3S", "value3"));
 
 		AbstractBuild build = mock(AbstractBuild.class);
-		when(build.getAction(ParametersAction.class)).thenReturn(new ParametersAction(oldParameters));
+		when(build.getAction(DynatraceVariablesAction.class)).thenReturn(new DynatraceVariablesAction(oldParameters));
 
 		Utils.updateBuildVariable(build, "key2S", "value2");
 
-		ArgumentCaptor<ParametersAction> argumentCaptor = ArgumentCaptor.forClass(ParametersAction.class);
-		verify(build).addAction(argumentCaptor.capture());
-		ParametersAction updatedAction = argumentCaptor.getValue();
+		ArgumentCaptor<DynatraceVariablesAction> argumentCaptor = ArgumentCaptor.forClass(DynatraceVariablesAction.class);
+		verify(build).replaceAction(argumentCaptor.capture());
+		DynatraceVariablesAction updatedAction = argumentCaptor.getValue();
 		assertUpdateBuildVariables(updatedAction);
 	}
 
-	private void assertUpdateBuildVariables(ParametersAction updatedAction) {
-		assertThat("ParametersAction cannot be null (was not modified?)", updatedAction, is(notNullValue()));
+	private void assertUpdateBuildVariables(DynatraceVariablesAction updatedAction) {
+		assertThat("DynatraceVariablesAction cannot be null (was not modified?)", updatedAction, is(notNullValue()));
 
 		List<ParameterValue> resultParameters = updatedAction.getParameters();
 		assertThat("Incorrect number of parameters", resultParameters, hasSize(3));


### PR DESCRIPTION
Jenkins patched one of their security issues in Jenkins 2.3 and Jenkins 1.x LTS:
https://wiki.jenkins-ci.org/display/JENKINS/Plugins+affected+by+fix+for+SECURITY-170

This PR aims to work-around limitations imposed on Dynatrace Jenkins Plugin.
Backward compatibility should remain the same.